### PR TITLE
Refactor/type hint

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,28 +2,27 @@ name: build
 on: [push]
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v2
-      with:
-        python-version: "3.10"
-    - name: Install dependencies
-      run: python -m pip install .[test] --upgrade pip
-    - name: Test with pytest
-      run: pytest
-    - name: Build package distribution
-      if: startsWith(github.ref, 'refs/tags')
-      run: |
-        python -m pip install build 
-        python -m build --sdist --wheel --outdir dist/ .
-    - name: Publish package distribution to PyPI
-      if: startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@master
-      with:
-        skip_existing: true
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
+      - uses: actions/checkout@v6
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: python -m pip install .[test] --upgrade pip
+      - name: Test with pytest
+        run: pytest
+      - name: Build package distribution
+        if: startsWith(github.ref, 'refs/tags')
+        run: |
+          python -m pip install build
+          python -m build --sdist --wheel --outdir dist/ .
+      - name: Publish package distribution to PyPI
+        if: startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip_existing: true
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "pplkit"
 version = "0.1.0"
 description = "Pipeline building toolkit"
 readme = "README.rst"
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 license = { file = "LICENSE" }
 authors = [
     { name = "IHME Math Sciences", email = "ihme.math.sciences@gmail.com" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,3 +26,7 @@ project = "pplkit"
 author = "IHME Math Sciences"
 copyright = "2023, IHME Math Sciences"
 version = "0.1.0"
+
+[tool.ruff]
+line-length = 80
+src = ["src"]

--- a/src/pplkit/data/interface.py
+++ b/src/pplkit/data/interface.py
@@ -28,7 +28,7 @@ class DataInterface:
     """
 
     def __init__(self, **dirs: str | pathlib.Path) -> None:
-        self.keys = []
+        self.keys: list[str] = []
         for key, value in dirs.items():
             self.add_dir(key, value)
 

--- a/src/pplkit/data/interface.py
+++ b/src/pplkit/data/interface.py
@@ -27,7 +27,7 @@ class DataInterface:
 
     """
 
-    def __init__(self, **dirs: dict[str, str | pathlib.Path]) -> None:
+    def __init__(self, **dirs: str | pathlib.Path) -> None:
         self.keys = []
         for key, value in dirs.items():
             self.add_dir(key, value)
@@ -77,7 +77,7 @@ class DataInterface:
             delattr(self, f"dump_{key}")
             self.keys.remove(key)
 
-    def get_fpath(self, *fparts: tuple[str, ...], key: str = "") -> pathlib.Path:
+    def get_fpath(self, *fparts: str, key: str = "") -> pathlib.Path:
         """Get the file path from the name of the directory and the sub-parts
         under the directory.
 
@@ -89,10 +89,12 @@ class DataInterface:
             The name of the directory stored in the class.
 
         """
-        return getattr(self, key, pathlib.Path(".")) / "/".join(map(str, fparts))
+        return getattr(self, key, pathlib.Path(".")) / "/".join(
+            map(str, fparts)
+        )
 
     def load(
-        self, *fparts: tuple[str, ...], key: str = "", **options: dict[str, typing.Any]
+        self, *fparts: str, key: str = "", **options: typing.Any
     ) -> typing.Any:
         """Load data from given directory.
 
@@ -120,7 +122,7 @@ class DataInterface:
         *fparts: str,
         key: str = "",
         mkdir: bool = True,
-        **options: dict[str, typing.Any],
+        **options: typing.Any,
     ):
         """Dump data to the given directory.
 

--- a/src/pplkit/data/interface.py
+++ b/src/pplkit/data/interface.py
@@ -123,7 +123,7 @@ class DataInterface:
         key: str = "",
         mkdir: bool = True,
         **options: typing.Any,
-    ):
+    ) -> None:
         """Dump data to the given directory.
 
         Parameters

--- a/src/pplkit/data/interface.py
+++ b/src/pplkit/data/interface.py
@@ -1,6 +1,6 @@
-from functools import partial
-from pathlib import Path
-from typing import Any
+import functools
+import pathlib
+import typing
 
 from pplkit.data.io import DataIO, dataio_dict
 
@@ -27,12 +27,14 @@ class DataInterface:
 
     """
 
-    def __init__(self, **dirs: dict[str, str | Path]) -> None:
+    def __init__(self, **dirs: dict[str, str | pathlib.Path]) -> None:
         self.keys = []
         for key, value in dirs.items():
             self.add_dir(key, value)
 
-    def add_dir(self, key: str, value: str | Path, exist_ok: bool = False) -> None:
+    def add_dir(
+        self, key: str, value: str | pathlib.Path, exist_ok: bool = False
+    ) -> None:
         """Add a directory to instance. If the directory already exist
 
         Parameters
@@ -54,9 +56,9 @@ class DataInterface:
         """
         if (not exist_ok) and (key in self.keys):
             raise ValueError(f"{key} already exists")
-        setattr(self, key, Path(value))
-        setattr(self, f"load_{key}", partial(self.load, key=key))
-        setattr(self, f"dump_{key}", partial(self.dump, key=key))
+        setattr(self, key, pathlib.Path(value))
+        setattr(self, f"load_{key}", functools.partial(self.load, key=key))
+        setattr(self, f"dump_{key}", functools.partial(self.dump, key=key))
         if key not in self.keys:
             self.keys.append(key)
 
@@ -75,7 +77,7 @@ class DataInterface:
             delattr(self, f"dump_{key}")
             self.keys.remove(key)
 
-    def get_fpath(self, *fparts: tuple[str, ...], key: str = "") -> Path:
+    def get_fpath(self, *fparts: tuple[str, ...], key: str = "") -> pathlib.Path:
         """Get the file path from the name of the directory and the sub-parts
         under the directory.
 
@@ -87,11 +89,11 @@ class DataInterface:
             The name of the directory stored in the class.
 
         """
-        return getattr(self, key, Path(".")) / "/".join(map(str, fparts))
+        return getattr(self, key, pathlib.Path(".")) / "/".join(map(str, fparts))
 
     def load(
-        self, *fparts: tuple[str, ...], key: str = "", **options: dict[str, Any]
-    ) -> Any:
+        self, *fparts: tuple[str, ...], key: str = "", **options: dict[str, typing.Any]
+    ) -> typing.Any:
         """Load data from given directory.
 
         Parameters
@@ -114,11 +116,11 @@ class DataInterface:
 
     def dump(
         self,
-        obj: Any,
+        obj: typing.Any,
         *fparts: str,
         key: str = "",
         mkdir: bool = True,
-        **options: dict[str, Any],
+        **options: dict[str, typing.Any],
     ):
         """Dump data to the given directory.
 

--- a/src/pplkit/data/io.py
+++ b/src/pplkit/data/io.py
@@ -29,7 +29,7 @@ class DataIO(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def _dump(self, obj: typing.Any, fpath: pathlib.Path, **options):
+    def _dump(self, obj: typing.Any, fpath: pathlib.Path, **options) -> None:
         pass
 
     def load(self, fpath: str | pathlib.Path, **options) -> typing.Any:
@@ -59,8 +59,12 @@ class DataIO(abc.ABC):
         return self._load(fpath, **options)
 
     def dump(
-        self, obj: typing.Any, fpath: str | pathlib.Path, mkdir: bool = True, **options
-    ):
+        self,
+        obj: typing.Any,
+        fpath: str | pathlib.Path,
+        mkdir: bool = True,
+        **options,
+    ) -> None:
         """Dump data to given path.
 
         Parameters
@@ -99,7 +103,7 @@ class CSVIO(DataIO):
     def _load(self, fpath: pathlib.Path, **options) -> pd.DataFrame:
         return pd.read_csv(fpath, **options)
 
-    def _dump(self, obj: pd.DataFrame, fpath: pathlib.Path, **options):
+    def _dump(self, obj: pd.DataFrame, fpath: pathlib.Path, **options) -> None:
         options = dict(index=False) | options
         obj.to_csv(fpath, **options)
 
@@ -111,7 +115,7 @@ class PickleIO(DataIO):
         with open(fpath, "rb") as f:
             return dill.load(f, **options)
 
-    def _dump(self, obj: typing.Any, fpath: pathlib.Path, **options):
+    def _dump(self, obj: typing.Any, fpath: pathlib.Path, **options) -> None:
         with open(fpath, "wb") as f:
             return dill.dump(obj, f, **options)
 
@@ -125,7 +129,7 @@ class YAMLIO(DataIO):
         with open(fpath, "r") as f:
             return yaml.load(f, **options)
 
-    def _dump(self, obj: dict | list, fpath: pathlib.Path, **options):
+    def _dump(self, obj: dict | list, fpath: pathlib.Path, **options) -> None:
         options = dict(Dumper=yaml.SafeDumper) | options
         with open(fpath, "w") as f:
             return yaml.dump(obj, f, **options)
@@ -139,7 +143,7 @@ class ParquetIO(DataIO):
         options = dict(engine="pyarrow") | options
         return pd.read_parquet(fpath, **options)
 
-    def _dump(self, obj: pd.DataFrame, fpath: pathlib.Path, **options):
+    def _dump(self, obj: pd.DataFrame, fpath: pathlib.Path, **options) -> None:
         options = dict(engine="pyarrow") | options
         obj.to_parquet(fpath, **options)
 
@@ -152,7 +156,7 @@ class JSONIO(DataIO):
         with open(fpath, "r") as f:
             return json.load(f, **options)
 
-    def _dump(self, obj: dict | list, fpath: pathlib.Path, **options):
+    def _dump(self, obj: dict | list, fpath: pathlib.Path, **options) -> None:
         with open(fpath, "w") as f:
             json.dump(obj, f, **options)
 
@@ -165,7 +169,7 @@ class TOMLIO(DataIO):
         with open(fpath, "rb") as f:
             return tomli.load(f, **options)
 
-    def _dump(self, obj: dict, fpath: pathlib.Path, **options):
+    def _dump(self, obj: dict, fpath: pathlib.Path, **options) -> None:
         with open(fpath, "wb") as f:
             tomli_w.dump(obj, f)
 

--- a/src/pplkit/data/io.py
+++ b/src/pplkit/data/io.py
@@ -1,7 +1,7 @@
+import abc
 import json
-from abc import ABC, abstractmethod
-from pathlib import Path
-from typing import Any
+import pathlib
+import typing
 
 import dill
 import pandas as pd
@@ -10,7 +10,7 @@ import tomli_w
 import yaml
 
 
-class DataIO(ABC):
+class DataIO(abc.ABC):
     """Bridge class that unifies the file I/O for different data types."""
 
     fextns: tuple[str, ...] = ("",)
@@ -24,15 +24,15 @@ class DataIO(ABC):
 
     """
 
-    @abstractmethod
-    def _load(self, fpath: Path, **options) -> Any:
+    @abc.abstractmethod
+    def _load(self, fpath: pathlib.Path, **options) -> typing.Any:
         pass
 
-    @abstractmethod
-    def _dump(self, obj: Any, fpath: Path, **options):
+    @abc.abstractmethod
+    def _dump(self, obj: typing.Any, fpath: pathlib.Path, **options):
         pass
 
-    def load(self, fpath: str | Path, **options) -> Any:
+    def load(self, fpath: str | pathlib.Path, **options) -> typing.Any:
         """Load data from given path.
 
         Parameters
@@ -53,12 +53,14 @@ class DataIO(ABC):
             Data loaded from the given path.
 
         """
-        fpath = Path(fpath)
+        fpath = pathlib.Path(fpath)
         if fpath.suffix not in self.fextns:
             raise ValueError(f"File extension must be in {self.fextns}.")
         return self._load(fpath, **options)
 
-    def dump(self, obj: Any, fpath: str | Path, mkdir: bool = True, **options):
+    def dump(
+        self, obj: typing.Any, fpath: str | pathlib.Path, mkdir: bool = True, **options
+    ):
         """Dump data to given path.
 
         Parameters
@@ -79,7 +81,7 @@ class DataIO(ABC):
             Raised when the given data object type doesn't match.
 
         """
-        fpath = Path(fpath)
+        fpath = pathlib.Path(fpath)
         if not isinstance(obj, self.dtypes):
             raise TypeError(f"Data must be an instance of {self.dtypes}.")
         if mkdir:
@@ -94,10 +96,10 @@ class CSVIO(DataIO):
     fextns: tuple[str, ...] = (".csv",)
     dtypes: tuple[type, ...] = (pd.DataFrame,)
 
-    def _load(self, fpath: Path, **options) -> pd.DataFrame:
+    def _load(self, fpath: pathlib.Path, **options) -> pd.DataFrame:
         return pd.read_csv(fpath, **options)
 
-    def _dump(self, obj: pd.DataFrame, fpath: Path, **options):
+    def _dump(self, obj: pd.DataFrame, fpath: pathlib.Path, **options):
         options = dict(index=False) | options
         obj.to_csv(fpath, **options)
 
@@ -105,11 +107,11 @@ class CSVIO(DataIO):
 class PickleIO(DataIO):
     fextns: tuple[str, ...] = (".pkl", ".pickle")
 
-    def _load(self, fpath: Path, **options) -> Any:
+    def _load(self, fpath: pathlib.Path, **options) -> typing.Any:
         with open(fpath, "rb") as f:
             return dill.load(f, **options)
 
-    def _dump(self, obj: Any, fpath: Path, **options):
+    def _dump(self, obj: typing.Any, fpath: pathlib.Path, **options):
         with open(fpath, "wb") as f:
             return dill.dump(obj, f, **options)
 
@@ -118,12 +120,12 @@ class YAMLIO(DataIO):
     fextns: tuple[str, ...] = (".yml", ".yaml")
     dtypes: tuple[type, ...] = (dict, list)
 
-    def _load(self, fpath: Path, **options) -> dict | list:
+    def _load(self, fpath: pathlib.Path, **options) -> dict | list:
         options = dict(Loader=yaml.SafeLoader) | options
         with open(fpath, "r") as f:
             return yaml.load(f, **options)
 
-    def _dump(self, obj: dict | list, fpath: Path, **options):
+    def _dump(self, obj: dict | list, fpath: pathlib.Path, **options):
         options = dict(Dumper=yaml.SafeDumper) | options
         with open(fpath, "w") as f:
             return yaml.dump(obj, f, **options)
@@ -133,11 +135,11 @@ class ParquetIO(DataIO):
     fextns: tuple[str, ...] = (".parquet",)
     dtypes: tuple[type, ...] = (pd.DataFrame,)
 
-    def _load(self, fpath: Path, **options) -> pd.DataFrame:
+    def _load(self, fpath: pathlib.Path, **options) -> pd.DataFrame:
         options = dict(engine="pyarrow") | options
         return pd.read_parquet(fpath, **options)
 
-    def _dump(self, obj: pd.DataFrame, fpath: Path, **options):
+    def _dump(self, obj: pd.DataFrame, fpath: pathlib.Path, **options):
         options = dict(engine="pyarrow") | options
         obj.to_parquet(fpath, **options)
 
@@ -146,11 +148,11 @@ class JSONIO(DataIO):
     fextns: tuple[str, ...] = (".json",)
     dtypes: tuple[type, ...] = (dict, list)
 
-    def _load(self, fpath: Path, **options) -> dict | list:
+    def _load(self, fpath: pathlib.Path, **options) -> dict | list:
         with open(fpath, "r") as f:
             return json.load(f, **options)
 
-    def _dump(self, obj: dict | list, fpath: Path, **options):
+    def _dump(self, obj: dict | list, fpath: pathlib.Path, **options):
         with open(fpath, "w") as f:
             json.dump(obj, f, **options)
 
@@ -159,11 +161,11 @@ class TOMLIO(DataIO):
     fextns: tuple[str, ...] = (".toml",)
     dtypes: tuple[type, ...] = (dict,)
 
-    def _load(self, fpath: Path, **options) -> dict:
+    def _load(self, fpath: pathlib.Path, **options) -> dict:
         with open(fpath, "rb") as f:
             return tomli.load(f, **options)
 
-    def _dump(self, obj: dict, fpath: Path, **options):
+    def _dump(self, obj: dict, fpath: pathlib.Path, **options):
         with open(fpath, "wb") as f:
             tomli_w.dump(obj, f)
 

--- a/src/pplkit/data/io.py
+++ b/src/pplkit/data/io.py
@@ -25,14 +25,18 @@ class DataIO(abc.ABC):
     """
 
     @abc.abstractmethod
-    def _load(self, fpath: pathlib.Path, **options) -> typing.Any:
+    def _load(self, fpath: pathlib.Path, **options: typing.Any) -> typing.Any:
         pass
 
     @abc.abstractmethod
-    def _dump(self, obj: typing.Any, fpath: pathlib.Path, **options) -> None:
+    def _dump(
+        self, obj: typing.Any, fpath: pathlib.Path, **options: typing.Any
+    ) -> None:
         pass
 
-    def load(self, fpath: str | pathlib.Path, **options) -> typing.Any:
+    def load(
+        self, fpath: str | pathlib.Path, **options: typing.Any
+    ) -> typing.Any:
         """Load data from given path.
 
         Parameters
@@ -63,7 +67,7 @@ class DataIO(abc.ABC):
         obj: typing.Any,
         fpath: str | pathlib.Path,
         mkdir: bool = True,
-        **options,
+        **options: typing.Any,
     ) -> None:
         """Dump data to given path.
 
@@ -100,10 +104,12 @@ class CSVIO(DataIO):
     fextns: tuple[str, ...] = (".csv",)
     dtypes: tuple[type, ...] = (pd.DataFrame,)
 
-    def _load(self, fpath: pathlib.Path, **options) -> pd.DataFrame:
+    def _load(self, fpath: pathlib.Path, **options: typing.Any) -> pd.DataFrame:
         return pd.read_csv(fpath, **options)
 
-    def _dump(self, obj: pd.DataFrame, fpath: pathlib.Path, **options) -> None:
+    def _dump(
+        self, obj: pd.DataFrame, fpath: pathlib.Path, **options: typing.Any
+    ) -> None:
         options = dict(index=False) | options
         obj.to_csv(fpath, **options)
 
@@ -111,11 +117,13 @@ class CSVIO(DataIO):
 class PickleIO(DataIO):
     fextns: tuple[str, ...] = (".pkl", ".pickle")
 
-    def _load(self, fpath: pathlib.Path, **options) -> typing.Any:
+    def _load(self, fpath: pathlib.Path, **options: typing.Any) -> typing.Any:
         with open(fpath, "rb") as f:
             return dill.load(f, **options)
 
-    def _dump(self, obj: typing.Any, fpath: pathlib.Path, **options) -> None:
+    def _dump(
+        self, obj: typing.Any, fpath: pathlib.Path, **options: typing.Any
+    ) -> None:
         with open(fpath, "wb") as f:
             return dill.dump(obj, f, **options)
 
@@ -124,12 +132,14 @@ class YAMLIO(DataIO):
     fextns: tuple[str, ...] = (".yml", ".yaml")
     dtypes: tuple[type, ...] = (dict, list)
 
-    def _load(self, fpath: pathlib.Path, **options) -> dict | list:
+    def _load(self, fpath: pathlib.Path, **options: typing.Any) -> dict | list:
         options = dict(Loader=yaml.SafeLoader) | options
         with open(fpath, "r") as f:
             return yaml.load(f, **options)
 
-    def _dump(self, obj: dict | list, fpath: pathlib.Path, **options) -> None:
+    def _dump(
+        self, obj: dict | list, fpath: pathlib.Path, **options: typing.Any
+    ) -> None:
         options = dict(Dumper=yaml.SafeDumper) | options
         with open(fpath, "w") as f:
             return yaml.dump(obj, f, **options)
@@ -139,11 +149,13 @@ class ParquetIO(DataIO):
     fextns: tuple[str, ...] = (".parquet",)
     dtypes: tuple[type, ...] = (pd.DataFrame,)
 
-    def _load(self, fpath: pathlib.Path, **options) -> pd.DataFrame:
+    def _load(self, fpath: pathlib.Path, **options: typing.Any) -> pd.DataFrame:
         options = dict(engine="pyarrow") | options
         return pd.read_parquet(fpath, **options)
 
-    def _dump(self, obj: pd.DataFrame, fpath: pathlib.Path, **options) -> None:
+    def _dump(
+        self, obj: pd.DataFrame, fpath: pathlib.Path, **options: typing.Any
+    ) -> None:
         options = dict(engine="pyarrow") | options
         obj.to_parquet(fpath, **options)
 
@@ -152,11 +164,13 @@ class JSONIO(DataIO):
     fextns: tuple[str, ...] = (".json",)
     dtypes: tuple[type, ...] = (dict, list)
 
-    def _load(self, fpath: pathlib.Path, **options) -> dict | list:
+    def _load(self, fpath: pathlib.Path, **options: typing.Any) -> dict | list:
         with open(fpath, "r") as f:
             return json.load(f, **options)
 
-    def _dump(self, obj: dict | list, fpath: pathlib.Path, **options) -> None:
+    def _dump(
+        self, obj: dict | list, fpath: pathlib.Path, **options: typing.Any
+    ) -> None:
         with open(fpath, "w") as f:
             json.dump(obj, f, **options)
 
@@ -165,11 +179,13 @@ class TOMLIO(DataIO):
     fextns: tuple[str, ...] = (".toml",)
     dtypes: tuple[type, ...] = (dict,)
 
-    def _load(self, fpath: pathlib.Path, **options) -> dict:
+    def _load(self, fpath: pathlib.Path, **options: typing.Any) -> dict:
         with open(fpath, "rb") as f:
             return tomli.load(f, **options)
 
-    def _dump(self, obj: dict, fpath: pathlib.Path, **options) -> None:
+    def _dump(
+        self, obj: dict, fpath: pathlib.Path, **options: typing.Any
+    ) -> None:
         with open(fpath, "wb") as f:
             tomli_w.dump(obj, f)
 

--- a/src/pplkit/data/io.py
+++ b/src/pplkit/data/io.py
@@ -1,7 +1,7 @@
 import json
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Any, Type
+from typing import Any
 
 import dill
 import pandas as pd
@@ -18,7 +18,7 @@ class DataIO(ABC):
     the file extension matches.
 
     """
-    dtypes: tuple[Type, ...] = (object,)
+    dtypes: tuple[type, ...] = (object,)
     """The data types. When dumping the data, it will be used to check if the
     data type matches.
 
@@ -92,7 +92,7 @@ class DataIO(ABC):
 
 class CSVIO(DataIO):
     fextns: tuple[str, ...] = (".csv",)
-    dtypes: tuple[Type, ...] = (pd.DataFrame,)
+    dtypes: tuple[type, ...] = (pd.DataFrame,)
 
     def _load(self, fpath: Path, **options) -> pd.DataFrame:
         return pd.read_csv(fpath, **options)
@@ -116,7 +116,7 @@ class PickleIO(DataIO):
 
 class YAMLIO(DataIO):
     fextns: tuple[str, ...] = (".yml", ".yaml")
-    dtypes: tuple[Type, ...] = (dict, list)
+    dtypes: tuple[type, ...] = (dict, list)
 
     def _load(self, fpath: Path, **options) -> dict | list:
         options = dict(Loader=yaml.SafeLoader) | options
@@ -131,7 +131,7 @@ class YAMLIO(DataIO):
 
 class ParquetIO(DataIO):
     fextns: tuple[str, ...] = (".parquet",)
-    dtypes: tuple[Type, ...] = (pd.DataFrame,)
+    dtypes: tuple[type, ...] = (pd.DataFrame,)
 
     def _load(self, fpath: Path, **options) -> pd.DataFrame:
         options = dict(engine="pyarrow") | options
@@ -144,7 +144,7 @@ class ParquetIO(DataIO):
 
 class JSONIO(DataIO):
     fextns: tuple[str, ...] = (".json",)
-    dtypes: tuple[Type, ...] = (dict, list)
+    dtypes: tuple[type, ...] = (dict, list)
 
     def _load(self, fpath: Path, **options) -> dict | list:
         with open(fpath, "r") as f:
@@ -157,7 +157,7 @@ class JSONIO(DataIO):
 
 class TOMLIO(DataIO):
     fextns: tuple[str, ...] = (".toml",)
-    dtypes: tuple[Type, ...] = (dict,)
+    dtypes: tuple[type, ...] = (dict,)
 
     def _load(self, fpath: Path, **options) -> dict:
         with open(fpath, "rb") as f:


### PR DESCRIPTION
## Summary

Modernize and fix type hints across `io.py` and `interface.py`.

## What Changed

**New files**
- None

**Modified files**
- `src/pplkit/data/io.py`
  - Replaced deprecated `typing.Type` with built-in `type`
  - Removed `Type` from `typing` imports
  - Changed import style from `from X import Y` to module-level imports (`import abc`, `import pathlib`, `import typing`)
  - Added `-> None` return type to all `_dump` and `dump` methods
  - Added `typing.Any` annotation to all untyped `**options` parameters
- `src/pplkit/data/interface.py`
  - Changed import style to module-level imports to match `io.py`
  - Fixed `**dirs` type hint from `dict[str, str | Path]` to `str | pathlib.Path`
  - Fixed `*fparts` type hint from `tuple[str, ...]` to `str` in `get_fpath` and `load`
  - Fixed `**options` type hint from `dict[str, typing.Any]` to `typing.Any`
  - Added `-> None` return type to `dump`
  - Added `list[str]` type annotation to `self.keys`
- `pyproject.toml`
  - Bumped `requires-python` from `>=3.10` to `>=3.12`
  - Added `[tool.ruff]` configuration

**Deleted files**
- None