### PR TITLE
Simplify IO

### DIFF
--- a/src/pplkit/data/interface.py
+++ b/src/pplkit/data/interface.py
@@ -2,7 +2,7 @@ import functools
 import pathlib
 import typing
 
-from pplkit.data.io import DataIO, dataio_dict
+from pplkit.data.io import SUFFIX_TO_IO
 
 
 class DataInterface:
@@ -15,15 +15,6 @@ class DataInterface:
         Directories to manage with directory's name as the name of the keyword
         argument's name and directory's path as the value of the keyword
         argument's value.
-
-    """
-
-    dataio_dict: dict[str, type[DataIO]] = dataio_dict
-    """A dictionary that maps the file extensions to the corresponding data io
-    class. This is a module-level variable from
-    :py:data:`pplkit.data.io.dataio_dict`.
-
-    :meta hide-value:
 
     """
 
@@ -114,7 +105,7 @@ class DataInterface:
 
         """
         fpath = self.get_fpath(*fparts, key=key)
-        return self.dataio_dict[fpath.suffix].load(fpath, **options)
+        return SUFFIX_TO_IO[fpath.suffix].load(fpath, **options)
 
     def dump(
         self,
@@ -142,7 +133,7 @@ class DataInterface:
 
         """
         fpath = self.get_fpath(*fparts, key=key)
-        self.dataio_dict[fpath.suffix].dump(obj, fpath, mkdir=mkdir, **options)
+        SUFFIX_TO_IO[fpath.suffix].dump(obj, fpath, mkdir=mkdir, **options)
 
     def __repr__(self) -> str:
         expr = f"{type(self).__name__}(\n"

--- a/src/pplkit/data/interface.py
+++ b/src/pplkit/data/interface.py
@@ -18,7 +18,7 @@ class DataInterface:
 
     """
 
-    dataio_dict: dict[str, DataIO] = dataio_dict
+    dataio_dict: dict[str, type[DataIO]] = dataio_dict
     """A dictionary that maps the file extensions to the corresponding data io
     class. This is a module-level variable from
     :py:data:`pplkit.data.io.dataio_dict`.

--- a/src/pplkit/data/io.py
+++ b/src/pplkit/data/io.py
@@ -10,12 +10,12 @@ import tomli_w
 import yaml
 
 
-class DataIO(abc.ABC):
+class IO(abc.ABC):
     """Bridge class that unifies the file I/O for different data types."""
 
     @classmethod
     @abc.abstractmethod
-    def _load(cls, fpath: pathlib.Path, **options: typing.Any) -> typing.Any:
+    def _load(cls, path: pathlib.Path, **options: typing.Any) -> typing.Any:
         pass
 
     @classmethod
@@ -23,20 +23,20 @@ class DataIO(abc.ABC):
     def _dump(
         cls,
         obj: typing.Any,
-        fpath: pathlib.Path,
+        path: pathlib.Path,
         **options: typing.Any,
     ) -> None:
         pass
 
     @classmethod
     def load(
-        cls, fpath: str | pathlib.Path, **options: typing.Any
+        cls, path: str | pathlib.Path, **options: typing.Any
     ) -> typing.Any:
         """Load data from given path.
 
         Parameters
         ----------
-        fpath
+        path
             Provided file path.
         options
             Extra arguments for the load function.
@@ -47,14 +47,14 @@ class DataIO(abc.ABC):
             Data loaded from the given path.
 
         """
-        fpath = pathlib.Path(fpath)
-        return cls._load(fpath, **options)
+        path = pathlib.Path(path)
+        return cls._load(path, **options)
 
     @classmethod
     def dump(
         cls,
         obj: typing.Any,
-        fpath: str | pathlib.Path,
+        path: str | pathlib.Path,
         mkdir: bool = True,
         **options: typing.Any,
     ) -> None:
@@ -64,7 +64,7 @@ class DataIO(abc.ABC):
         ----------
         obj
             Provided data object.
-        fpath
+        path
             Provided file path.
         mkdir
             If true, it will automatically create the parent directory. The
@@ -73,116 +73,116 @@ class DataIO(abc.ABC):
             Extra arguments for the dump function.
 
         """
-        fpath = pathlib.Path(fpath)
+        path = pathlib.Path(path)
         if mkdir:
-            fpath.parent.mkdir(parents=True, exist_ok=True)
-        cls._dump(obj, fpath, **options)
+            path.parent.mkdir(parents=True, exist_ok=True)
+        cls._dump(obj, path, **options)
 
 
-class CSVIO(DataIO):
+class CSVIO(IO):
     @classmethod
-    def _load(cls, fpath: pathlib.Path, **options: typing.Any) -> pd.DataFrame:
-        return pd.read_csv(fpath, **options)
+    def _load(cls, path: pathlib.Path, **options: typing.Any) -> pd.DataFrame:
+        return pd.read_csv(path, **options)
 
     @classmethod
     def _dump(
         cls,
         obj: pd.DataFrame,
-        fpath: pathlib.Path,
+        path: pathlib.Path,
         **options: typing.Any,
     ) -> None:
         options = dict(index=False) | options
-        obj.to_csv(fpath, **options)
+        obj.to_csv(path, **options)
 
 
-class PickleIO(DataIO):
+class PickleIO(IO):
     @classmethod
-    def _load(cls, fpath: pathlib.Path, **options: typing.Any) -> typing.Any:
-        with open(fpath, "rb") as f:
+    def _load(cls, path: pathlib.Path, **options: typing.Any) -> typing.Any:
+        with open(path, "rb") as f:
             return dill.load(f, **options)
 
     @classmethod
     def _dump(
         cls,
         obj: typing.Any,
-        fpath: pathlib.Path,
+        path: pathlib.Path,
         **options: typing.Any,
     ) -> None:
-        with open(fpath, "wb") as f:
+        with open(path, "wb") as f:
             dill.dump(obj, f, **options)
 
 
-class YAMLIO(DataIO):
+class YAMLIO(IO):
     @classmethod
-    def _load(cls, fpath: pathlib.Path, **options: typing.Any) -> dict | list:
+    def _load(cls, path: pathlib.Path, **options: typing.Any) -> dict | list:
         options = dict(Loader=yaml.SafeLoader) | options
-        with open(fpath, "r") as f:
+        with open(path, "r") as f:
             return yaml.load(f, **options)
 
     @classmethod
     def _dump(
         cls,
         obj: dict | list,
-        fpath: pathlib.Path,
+        path: pathlib.Path,
         **options: typing.Any,
     ) -> None:
         options = dict(Dumper=yaml.SafeDumper) | options
-        with open(fpath, "w") as f:
+        with open(path, "w") as f:
             yaml.dump(obj, f, **options)
 
 
-class ParquetIO(DataIO):
+class ParquetIO(IO):
     @classmethod
-    def _load(cls, fpath: pathlib.Path, **options: typing.Any) -> pd.DataFrame:
+    def _load(cls, path: pathlib.Path, **options: typing.Any) -> pd.DataFrame:
         options = dict(engine="pyarrow") | options
-        return pd.read_parquet(fpath, **options)
+        return pd.read_parquet(path, **options)
 
     @classmethod
     def _dump(
         cls,
         obj: pd.DataFrame,
-        fpath: pathlib.Path,
+        path: pathlib.Path,
         **options: typing.Any,
     ) -> None:
         options = dict(engine="pyarrow") | options
-        obj.to_parquet(fpath, **options)
+        obj.to_parquet(path, **options)
 
 
-class JSONIO(DataIO):
+class JSONIO(IO):
     @classmethod
-    def _load(cls, fpath: pathlib.Path, **options: typing.Any) -> dict | list:
-        with open(fpath, "r") as f:
+    def _load(cls, path: pathlib.Path, **options: typing.Any) -> dict | list:
+        with open(path, "r") as f:
             return json.load(f, **options)
 
     @classmethod
     def _dump(
         cls,
         obj: dict | list,
-        fpath: pathlib.Path,
+        path: pathlib.Path,
         **options: typing.Any,
     ) -> None:
-        with open(fpath, "w") as f:
+        with open(path, "w") as f:
             json.dump(obj, f, **options)
 
 
-class TOMLIO(DataIO):
+class TOMLIO(IO):
     @classmethod
-    def _load(cls, fpath: pathlib.Path, **options: typing.Any) -> dict:
-        with open(fpath, "rb") as f:
+    def _load(cls, path: pathlib.Path, **options: typing.Any) -> dict:
+        with open(path, "rb") as f:
             return tomllib.load(f, **options)
 
     @classmethod
     def _dump(
         cls,
         obj: dict,
-        fpath: pathlib.Path,
+        path: pathlib.Path,
         **options: typing.Any,
     ) -> None:
-        with open(fpath, "wb") as f:
+        with open(path, "wb") as f:
             tomli_w.dump(obj, f, **options)
 
 
-dataio_dict: dict[str, type[DataIO]] = {
+SUFFIX_TO_IO: dict[str, type[IO]] = {
     ".csv": CSVIO,
     ".pkl": PickleIO,
     ".pickle": PickleIO,
@@ -192,7 +192,6 @@ dataio_dict: dict[str, type[DataIO]] = {
     ".json": JSONIO,
     ".toml": TOMLIO,
 }
-"""Data IO classes, organized in a dictionary with key as the file
-extensions for each :class:`DataIO` class.
+"""Mapping from file suffix to the corresponding :class:`IO` class.
 
 """

--- a/tests/data/test_io.py
+++ b/tests/data/test_io.py
@@ -14,27 +14,24 @@ def data() -> dict[str, list[int]]:
 
 def test_csvio(data: dict[str, list[int]], tmp_path: pathlib.Path) -> None:
     df = pd.DataFrame(data)
-    port = CSVIO()
-    port.dump(df, tmp_path / "file.csv")
-    loaded_data = port.load(tmp_path / "file.csv")
+    CSVIO.dump(df, tmp_path / "file.csv")
+    loaded_data = CSVIO.load(tmp_path / "file.csv")
 
     for key in ["a", "b"]:
         assert np.allclose(data[key], loaded_data[key])
 
 
 def test_jsonio(data: dict[str, list[int]], tmp_path: pathlib.Path) -> None:
-    port = JSONIO()
-    port.dump(data, tmp_path / "file.json")
-    loaded_data = port.load(tmp_path / "file.json")
+    JSONIO.dump(data, tmp_path / "file.json")
+    loaded_data = JSONIO.load(tmp_path / "file.json")
 
     for key in ["a", "b"]:
         assert np.allclose(data[key], loaded_data[key])
 
 
 def test_yamlio(data: dict[str, list[int]], tmp_path: pathlib.Path) -> None:
-    port = YAMLIO()
-    port.dump(data, tmp_path / "file.yaml")
-    loaded_data = port.load(tmp_path / "file.yaml")
+    YAMLIO.dump(data, tmp_path / "file.yaml")
+    loaded_data = YAMLIO.load(tmp_path / "file.yaml")
 
     for key in ["a", "b"]:
         assert np.allclose(data[key], loaded_data[key])
@@ -42,47 +39,41 @@ def test_yamlio(data: dict[str, list[int]], tmp_path: pathlib.Path) -> None:
 
 def test_parquetio(data: dict[str, list[int]], tmp_path: pathlib.Path) -> None:
     df = pd.DataFrame(data)
-    port = ParquetIO()
-    port.dump(df, tmp_path / "file.parquet")
-    loaded_data = port.load(tmp_path / "file.parquet")
+    ParquetIO.dump(df, tmp_path / "file.parquet")
+    loaded_data = ParquetIO.load(tmp_path / "file.parquet")
 
     for key in ["a", "b"]:
         assert np.allclose(data[key], loaded_data[key])
 
 
 def test_pickleio(data: dict[str, list[int]], tmp_path: pathlib.Path) -> None:
-    port = PickleIO()
-    port.dump(data, tmp_path / "file.pkl")
-    loaded_data = port.load(tmp_path / "file.pkl")
+    PickleIO.dump(data, tmp_path / "file.pkl")
+    loaded_data = PickleIO.load(tmp_path / "file.pkl")
 
     for key in ["a", "b"]:
         assert np.allclose(data[key], loaded_data[key])
 
 
 def test_tomlio(data: dict[str, list[int]], tmp_path: pathlib.Path) -> None:
-    port = TOMLIO()
-    port.dump(data, tmp_path / "file.toml")
-    loaded_data = port.load(tmp_path / "file.toml")
+    TOMLIO.dump(data, tmp_path / "file.toml")
+    loaded_data = TOMLIO.load(tmp_path / "file.toml")
 
     for key in ["a", "b"]:
         assert np.allclose(data[key], loaded_data[key])
 
 
 def test_load_invalid_extension(tmp_path: pathlib.Path) -> None:
-    port = CSVIO()
     fpath = tmp_path / "file.txt"
     fpath.touch()
     with pytest.raises(ValueError, match="File extension must be in"):
-        port.load(fpath)
+        CSVIO.load(fpath)
 
 
 def test_dump_invalid_type(tmp_path: pathlib.Path) -> None:
-    port = CSVIO()
     with pytest.raises(TypeError, match="Data must be an instance of"):
-        port.dump({"a": 1}, tmp_path / "file.csv")
+        CSVIO.dump({"a": 1}, tmp_path / "file.csv")
 
 
 def test_load_missing_file(tmp_path: pathlib.Path) -> None:
-    port = JSONIO()
     with pytest.raises(FileNotFoundError):
-        port.load(tmp_path / "nonexistent.json")
+        JSONIO.load(tmp_path / "nonexistent.json")

--- a/tests/data/test_io.py
+++ b/tests/data/test_io.py
@@ -62,18 +62,6 @@ def test_tomlio(data: dict[str, list[int]], tmp_path: pathlib.Path) -> None:
         assert np.allclose(data[key], loaded_data[key])
 
 
-def test_load_invalid_extension(tmp_path: pathlib.Path) -> None:
-    fpath = tmp_path / "file.txt"
-    fpath.touch()
-    with pytest.raises(ValueError, match="File extension must be in"):
-        CSVIO.load(fpath)
-
-
-def test_dump_invalid_type(tmp_path: pathlib.Path) -> None:
-    with pytest.raises(TypeError, match="Data must be an instance of"):
-        CSVIO.dump({"a": 1}, tmp_path / "file.csv")
-
-
 def test_load_missing_file(tmp_path: pathlib.Path) -> None:
     with pytest.raises(FileNotFoundError):
         JSONIO.load(tmp_path / "nonexistent.json")


### PR DESCRIPTION
Summary

Refactor `DataIO` classes to use classmethods instead of singleton instances, simplify by removing redundant validation attributes, and improve naming throughout.

## What Changed

**New files**
- None

**Modified files**
- `src/pplkit/data/io.py`
  - Renamed `DataIO` → `IO`
  - Converted all instance methods to `@classmethod`
  - Removed `fextns` and `dtypes` class attributes and their validation logic from `load`/`dump`
  - Removed `__repr__` method
  - Removed module-level singleton instances (`csvio`, `yamlio`, etc.) and `_dataio_list`
  - Renamed `dataio_dict` → `SUFFIX_TO_IO` as an explicit module-level constant
  - Renamed `fpath` → `path` in all methods and docstrings
- `src/pplkit/data/interface.py`
  - Removed `DataIO` import and `dataio_dict` class attribute
  - Uses `SUFFIX_TO_IO` directly from module import
- `tests/data/test_io.py`
  - Call IO classes directly (`CSVIO.load(...)`) instead of instantiating them
  - Removed `test_load_invalid_extension` and `test_dump_invalid_type` (validation no longer exists)

**Deleted files**
- None