### PR TITLE
Refactor/io

### DIFF
--- a/src/pplkit/data/interface.py
+++ b/src/pplkit/data/interface.py
@@ -1,31 +1,42 @@
+"""High-level data interface for reading and writing files by directory key.
+
+:class:`DataInterface` pairs named directory paths with the registry-based
+I/O layer in :mod:`pplkit.data.io` so that callers can load and dump data
+with a single call, e.g.
+
+>>> dataif = DataInterface(raw="/data/raw", output="/data/output")
+>>> dataif.dump(my_df, "results.csv", key="output")
+>>> df = dataif.load("results.csv", key="output")
+
+File format is determined automatically from the file extension.
+
+"""
+
 import os
 import pathlib
 import typing
 
-from pplkit.data.io import (
-    get_default_loader,
-    get_dumper,
-    get_dumper_obj_types,
-    get_loader,
-    get_loader_obj_types,
-    resolve_obj_type,
-    resolve_suffix,
-)
+from pplkit.data.io import DumperRegistry, LoaderRegistry
 
 type PathLike = str | os.PathLike[str]
+"""A string or :class:`os.PathLike` that can be coerced to a
+:class:`~pathlib.Path`.
+
+"""
 
 
 class DataInterface:
-    """Data interface that manages named directories and automatically reads
-    and writes data based on file extension.
+    """Manage named directories and automatically read/write data by extension.
 
     Directories are registered by name and accessed via bracket notation.
-    Values are coerced to ``pathlib.Path`` on insertion.
+    Values are coerced to :class:`~pathlib.Path` on insertion.
 
     Parameters
     ----------
     paths
-        Directories to manage, passed as keyword arguments.
+        Directories to manage, passed as keyword arguments.  Keys are
+        short names (e.g. ``"raw"``, ``"output"``); values are directory
+        paths (strings or :class:`~pathlib.Path` objects).
 
     Examples
     --------
@@ -42,24 +53,6 @@ class DataInterface:
         for key, value in paths.items():
             self[key] = value
 
-    def __getitem__(self, key: str | None) -> pathlib.Path:
-        if key is None:
-            return pathlib.Path()
-        return self._paths[key]
-
-    def __setitem__(self, key: str, value: PathLike) -> None:
-        if not isinstance(key, str):
-            raise TypeError(
-                f"DataInterface key must be a 'str', not {type(key).__name__!r}"
-            )
-        self._paths[key] = pathlib.Path(value)
-
-    def __delitem__(self, key: str) -> None:
-        del self._paths[key]
-
-    def __len__(self) -> int:
-        return len(self._paths)
-
     def load(
         self,
         sub_path: PathLike,
@@ -68,40 +61,46 @@ class DataInterface:
         suffix: str | None = None,
         **options: typing.Any,
     ) -> typing.Any:
-        """Load data from a file. The file format is inferred from the suffix.
+        """Load data from a file.
+
+        The file format is inferred from the suffix of *sub_path* (or from
+        the explicit *suffix* override).
 
         Parameters
         ----------
         sub_path
-            Relative path to the file under the registered directory. If
-            ``key`` is ``None``, this is used as the full path.
+            Relative path to the file under the registered directory.  If
+            *key* is ``None``, this is used as the full/absolute path.
         key
-            Name of a registered directory. If ``None``, ``sub_path`` is
+            Name of a registered directory.  If ``None``, *sub_path* is
             used as-is.
         obj_type
-            Desired object type for the loaded data. If ``None``, the
-            default loader for the suffix is used.
+            Desired Python type for the loaded data.  When ``None`` the
+            default loader for the suffix is used (e.g. ``object`` for
+            JSON, ``pd.DataFrame`` for CSV).
         suffix
-            Override the file suffix for format resolution. If ``None``,
-            the suffix is inferred from ``sub_path``.
+            Override the file suffix used for format resolution.  When
+            ``None``, the suffix is taken from *sub_path*.
         options
-            Extra keyword arguments passed to the underlying loader.
+            Extra keyword arguments forwarded to the underlying loader.
 
         Returns
         -------
         Any
             Data loaded from the given path.
 
+        Raises
+        ------
+        KeyError
+            If *key* is not ``None`` and has not been registered.
+        FileNotFoundError
+            If the resolved path does not exist on disk.
+
         """
         path = self[key] / sub_path
-        resolved_suffix = resolve_suffix(suffix or path.suffix)
-        if obj_type is None:
-            loader = get_default_loader(resolved_suffix)
-        else:
-            obj_type = resolve_obj_type(
-                obj_type, get_loader_obj_types(resolved_suffix)
-            )
-            loader = get_loader(resolved_suffix, obj_type)
+        loader = LoaderRegistry.get_loader(
+            suffix=suffix or path.suffix, obj_type=obj_type
+        )
         return loader(path, **options)
 
     def dump(
@@ -113,39 +112,120 @@ class DataInterface:
         suffix: str | None = None,
         **options: typing.Any,
     ) -> None:
-        """Dump data to a file. The file format is inferred from the suffix.
+        """Dump data to a file.
+
+        The file format is inferred from the suffix of *sub_path* (or from
+        the explicit *suffix* override).
 
         Parameters
         ----------
         obj
             Data object to write.
         sub_path
-            Relative path to the file under the registered directory. If
-            ``key`` is ``None``, this is used as the full path.
+            Relative path to the file under the registered directory.  If
+            *key* is ``None``, this is used as the full/absolute path.
         key
-            Name of a registered directory. If ``None``, ``sub_path`` is
+            Name of a registered directory.  If ``None``, *sub_path* is
             used as-is.
         mkdir
-            If ``True``, automatically create the parent directory. Default
-            is ``True``.
+            If ``True`` (the default), automatically create the parent
+            directory and any missing ancestors.
         suffix
-            Override the file suffix for format resolution. If ``None``,
-            the suffix is inferred from ``sub_path``.
+            Override the file suffix used for format resolution.  When
+            ``None``, the suffix is taken from *sub_path*.
         options
-            Extra keyword arguments passed to the underlying dumper.
+            Extra keyword arguments forwarded to the underlying dumper.
+
+        Raises
+        ------
+        KeyError
+            If *key* is not ``None`` and has not been registered.
 
         """
         path = self[key] / sub_path
         if mkdir:
             path.parent.mkdir(parents=True, exist_ok=True)
-        resolved_suffix = resolve_suffix(suffix or path.suffix)
-        obj_type = resolve_obj_type(
-            type(obj), get_dumper_obj_types(resolved_suffix)
+        dumper = DumperRegistry.get_dumper(
+            suffix=suffix or path.suffix, obj_type=type(obj)
         )
-        dumper = get_dumper(resolved_suffix, obj_type)
         dumper(obj, path, **options)
 
+    def __getitem__(self, key: str | None) -> pathlib.Path:
+        """Return the path registered under *key*.
+
+        If *key* is ``None`` an empty :class:`~pathlib.Path` is returned,
+        which lets callers pass absolute sub-paths through
+        :meth:`load`/:meth:`dump` without a registered directory.
+
+        Parameters
+        ----------
+        key
+            Registered directory name, or ``None``.
+
+        Returns
+        -------
+        pathlib.Path
+            The registered directory path (or ``Path()`` when *key* is
+            ``None``).
+
+        Raises
+        ------
+        KeyError
+            If *key* is not ``None`` and has not been registered.
+
+        """
+        if key is None:
+            return pathlib.Path()
+        return self._paths[key]
+
+    def __setitem__(self, key: str, value: PathLike) -> None:
+        """Register or overwrite the directory path for *key*.
+
+        *value* is coerced to :class:`~pathlib.Path`.
+
+        Parameters
+        ----------
+        key
+            Directory name.  Must be a ``str``.
+        value
+            Directory path (``str`` or path-like).
+
+        Raises
+        ------
+        TypeError
+            If *key* is not a ``str``.
+
+        """
+        if not isinstance(key, str):
+            raise TypeError(
+                f"DataInterface key must be a 'str', not {type(key).__name__!r}"
+            )
+        self._paths[key] = pathlib.Path(value)
+
+    def __delitem__(self, key: str) -> None:
+        """Remove the directory registered under *key*.
+
+        Raises
+        ------
+        KeyError
+            If *key* has not been registered.
+
+        """
+        del self._paths[key]
+
+    def __len__(self) -> int:
+        """Return the number of registered directories."""
+        return len(self._paths)
+
     def __repr__(self) -> str:
+        """Return a concise, eval-style representation of the interface.
+
+        Examples
+        --------
+        >>> DataInterface(raw='/data/raw', output='/data/output')
+        DataInterface(raw='/data/raw', output='/data/output')
+
+        """
         items = ", ".join(
             f"{key}='{value}'" for key, value in self._paths.items()
         )

--- a/src/pplkit/data/io.py
+++ b/src/pplkit/data/io.py
@@ -1,4 +1,3 @@
-import abc
 import json
 import pathlib
 import tomllib
@@ -9,189 +8,190 @@ import pandas as pd
 import tomli_w
 import yaml
 
-
-class IO(abc.ABC):
-    """Bridge class that unifies the file I/O for different data types."""
-
-    @classmethod
-    @abc.abstractmethod
-    def _load(cls, path: pathlib.Path, **options: typing.Any) -> typing.Any:
-        pass
-
-    @classmethod
-    @abc.abstractmethod
-    def _dump(
-        cls,
-        obj: typing.Any,
-        path: pathlib.Path,
-        **options: typing.Any,
-    ) -> None:
-        pass
-
-    @classmethod
-    def load(
-        cls, path: str | pathlib.Path, **options: typing.Any
-    ) -> typing.Any:
-        """Load data from given path.
-
-        Parameters
-        ----------
-        path
-            Provided file path.
-        options
-            Extra arguments for the load function.
-
-        Returns
-        -------
-        Any
-            Data loaded from the given path.
-
-        """
-        path = pathlib.Path(path)
-        return cls._load(path, **options)
-
-    @classmethod
-    def dump(
-        cls,
-        obj: typing.Any,
-        path: str | pathlib.Path,
-        mkdir: bool = True,
-        **options: typing.Any,
-    ) -> None:
-        """Dump data to given path.
-
-        Parameters
-        ----------
-        obj
-            Provided data object.
-        path
-            Provided file path.
-        mkdir
-            If true, it will automatically create the parent directory. The
-            default is true.
-        options
-            Extra arguments for the dump function.
-
-        """
-        path = pathlib.Path(path)
-        if mkdir:
-            path.parent.mkdir(parents=True, exist_ok=True)
-        cls._dump(obj, path, **options)
+type Suffix = str
+type SuffixAlias = str
 
 
-class CSVIO(IO):
-    @classmethod
-    def _load(cls, path: pathlib.Path, **options: typing.Any) -> pd.DataFrame:
-        return pd.read_csv(path, **options)
-
-    @classmethod
-    def _dump(
-        cls,
-        obj: pd.DataFrame,
-        path: pathlib.Path,
-        **options: typing.Any,
-    ) -> None:
-        options = dict(index=False) | options
-        obj.to_csv(path, **options)
+class Loader[T](typing.Protocol):
+    def __call__(self, path: pathlib.Path, **options: typing.Any) -> T: ...
 
 
-class PickleIO(IO):
-    @classmethod
-    def _load(cls, path: pathlib.Path, **options: typing.Any) -> typing.Any:
-        with open(path, "rb") as f:
-            return dill.load(f, **options)
-
-    @classmethod
-    def _dump(
-        cls,
-        obj: typing.Any,
-        path: pathlib.Path,
-        **options: typing.Any,
-    ) -> None:
-        with open(path, "wb") as f:
-            dill.dump(obj, f, **options)
+class Dumper[T](typing.Protocol):
+    def __call__(
+        self, obj: T, path: pathlib.Path, **options: typing.Any
+    ) -> None: ...
 
 
-class YAMLIO(IO):
-    @classmethod
-    def _load(cls, path: pathlib.Path, **options: typing.Any) -> dict | list:
-        options = dict(Loader=yaml.SafeLoader) | options
-        with open(path, "r") as f:
-            return yaml.load(f, **options)
-
-    @classmethod
-    def _dump(
-        cls,
-        obj: dict | list,
-        path: pathlib.Path,
-        **options: typing.Any,
-    ) -> None:
-        options = dict(Dumper=yaml.SafeDumper) | options
-        with open(path, "w") as f:
-            yaml.dump(obj, f, **options)
+_loaders: dict[tuple[Suffix, type], Loader[typing.Any]] = {}
+_dumpers: dict[tuple[Suffix, type], Dumper[typing.Any]] = {}
+_loader_obj_types: dict[Suffix, list[type]] = {}
+_dumper_obj_types: dict[Suffix, list[type]] = {}
+_suffix_aliases: dict[SuffixAlias, Suffix] = {}
 
 
-class ParquetIO(IO):
-    @classmethod
-    def _load(cls, path: pathlib.Path, **options: typing.Any) -> pd.DataFrame:
-        options = dict(engine="pyarrow") | options
-        return pd.read_parquet(path, **options)
-
-    @classmethod
-    def _dump(
-        cls,
-        obj: pd.DataFrame,
-        path: pathlib.Path,
-        **options: typing.Any,
-    ) -> None:
-        options = dict(engine="pyarrow") | options
-        obj.to_parquet(path, **options)
+def register_suffix_alias(suffix: Suffix, suffix_alias: SuffixAlias) -> None:
+    _suffix_aliases[suffix_alias] = suffix
 
 
-class JSONIO(IO):
-    @classmethod
-    def _load(cls, path: pathlib.Path, **options: typing.Any) -> dict | list:
-        with open(path, "r") as f:
-            return json.load(f, **options)
-
-    @classmethod
-    def _dump(
-        cls,
-        obj: dict | list,
-        path: pathlib.Path,
-        **options: typing.Any,
-    ) -> None:
-        with open(path, "w") as f:
-            json.dump(obj, f, **options)
+def resolve_suffix(suffix: Suffix) -> str:
+    return _suffix_aliases.get(suffix, suffix)
 
 
-class TOMLIO(IO):
-    @classmethod
-    def _load(cls, path: pathlib.Path, **options: typing.Any) -> dict:
-        with open(path, "rb") as f:
-            return tomllib.load(f, **options)
-
-    @classmethod
-    def _dump(
-        cls,
-        obj: dict,
-        path: pathlib.Path,
-        **options: typing.Any,
-    ) -> None:
-        with open(path, "wb") as f:
-            tomli_w.dump(obj, f, **options)
+def _register_obj_type(
+    suffix: Suffix,
+    obj_type: type,
+    object_type_registry: dict[Suffix, list[type]],
+) -> None:
+    obj_types = object_type_registry.get(suffix, [])
+    if obj_type not in obj_types:
+        if obj_type is object:
+            obj_types.append(obj_type)
+        else:
+            obj_types.insert(0, obj_type)
+    object_type_registry[suffix] = obj_types
 
 
-SUFFIX_TO_IO: dict[str, type[IO]] = {
-    ".csv": CSVIO,
-    ".pkl": PickleIO,
-    ".pickle": PickleIO,
-    ".yml": YAMLIO,
-    ".yaml": YAMLIO,
-    ".parquet": ParquetIO,
-    ".json": JSONIO,
-    ".toml": TOMLIO,
-}
-"""Mapping from file suffix to the corresponding :class:`IO` class.
+def resolve_obj_type(obj_type: type, registered_obj_types: list[type]) -> type:
+    if obj_type in registered_obj_types:
+        return obj_type
+    for registered_obj_type in registered_obj_types:
+        if issubclass(obj_type, registered_obj_type):
+            return registered_obj_type
+    raise TypeError(
+        f"Cannot resolve {obj_type.__name__!r} from "
+        f"{[t.__name__ for t in registered_obj_types]}"
+    )
 
-"""
+
+def get_default_loader(suffix: Suffix) -> Loader[typing.Any]:
+    default_obj_type = _loader_obj_types[suffix][-1]
+    return _loaders[(suffix, default_obj_type)]
+
+
+def get_loader(suffix: Suffix, obj_type: type) -> Loader[typing.Any]:
+    return _loaders[(suffix, obj_type)]
+
+
+def get_dumper(suffix: Suffix, obj_type: type) -> Dumper[typing.Any]:
+    return _dumpers[(suffix, obj_type)]
+
+
+def get_loader_obj_types(suffix: Suffix) -> list[type]:
+    return _loader_obj_types[suffix]
+
+
+def get_dumper_obj_types(suffix: Suffix) -> list[type]:
+    return _dumper_obj_types[suffix]
+
+
+def register_loader(
+    suffix: Suffix, obj_type: type
+) -> typing.Callable[[Loader[typing.Any]], Loader[typing.Any]]:
+    def register_loader_decorator(
+        loader: Loader[typing.Any],
+    ) -> Loader[typing.Any]:
+        _loaders[(suffix, obj_type)] = loader
+        _register_obj_type(suffix, obj_type, _loader_obj_types)
+        return loader
+
+    return register_loader_decorator
+
+
+def register_dumper(
+    suffix: Suffix, obj_type: type
+) -> typing.Callable[[Dumper[typing.Any]], Dumper[typing.Any]]:
+    def register_dumper_decorator(
+        dumper: Dumper[typing.Any],
+    ) -> Dumper[typing.Any]:
+        _dumpers[(suffix, obj_type)] = dumper
+        _register_obj_type(suffix, obj_type, _dumper_obj_types)
+        return dumper
+
+    return register_dumper_decorator
+
+
+@register_loader(".csv", pd.DataFrame)
+def load_csv_as_pandas(
+    path: pathlib.Path, **options: typing.Any
+) -> pd.DataFrame:
+    return pd.read_csv(path, **options)
+
+
+@register_dumper(".csv", pd.DataFrame)
+def dump_csv_from_pandas(
+    obj: pd.DataFrame, path: pathlib.Path, **options: typing.Any
+) -> None:
+    options = dict(index=False) | options
+    obj.to_csv(path, **options)
+
+
+@register_loader(".pkl", object)
+def load_pickle(path: pathlib.Path, **options: typing.Any) -> typing.Any:
+    with open(path, "rb") as f:
+        return dill.load(f, **options)
+
+
+@register_dumper(".pkl", object)
+def dump_pickle(
+    obj: typing.Any, path: pathlib.Path, **options: typing.Any
+) -> None:
+    with open(path, "wb") as f:
+        dill.dump(obj, f, **options)
+
+
+@register_loader(".yaml", object)
+def load_yaml(path: pathlib.Path, **options: typing.Any) -> object:
+    options = dict(Loader=yaml.SafeLoader) | options
+    with open(path, "r") as f:
+        return yaml.load(f, **options)
+
+
+@register_dumper(".yaml", object)
+def dump_yaml(obj: object, path: pathlib.Path, **options: typing.Any) -> None:
+    options = dict(Dumper=yaml.SafeDumper) | options
+    with open(path, "w") as f:
+        yaml.dump(obj, f, **options)
+
+
+@register_loader(".parquet", pd.DataFrame)
+def load_parquet_as_pandas(
+    path: pathlib.Path, **options: typing.Any
+) -> pd.DataFrame:
+    options = dict(engine="pyarrow") | options
+    return pd.read_parquet(path, **options)
+
+
+@register_dumper(".parquet", pd.DataFrame)
+def dump_parquet_from_pandas(
+    obj: pd.DataFrame, path: pathlib.Path, **options: typing.Any
+) -> None:
+    options = dict(engine="pyarrow") | options
+    obj.to_parquet(path, **options)
+
+
+@register_loader(".json", object)
+def load_json(path: pathlib.Path, **options: typing.Any) -> object:
+    with open(path, "r") as f:
+        return json.load(f, **options)
+
+
+@register_dumper(".json", object)
+def dump_json(obj: object, path: pathlib.Path, **options: typing.Any) -> None:
+    with open(path, "w") as f:
+        json.dump(obj, f, **options)
+
+
+@register_loader(".toml", dict)
+def load_toml(path: pathlib.Path, **options: typing.Any) -> dict:
+    with open(path, "rb") as f:
+        return tomllib.load(f, **options)
+
+
+@register_dumper(".toml", dict)
+def dump_toml(obj: dict, path: pathlib.Path, **options: typing.Any) -> None:
+    with open(path, "wb") as f:
+        tomli_w.dump(obj, f, **options)
+
+
+register_suffix_alias(suffix=".pkl", suffix_alias=".pickle")
+register_suffix_alias(suffix=".yaml", suffix_alias=".yml")

--- a/tests/data/test_io.py
+++ b/tests/data/test_io.py
@@ -47,20 +47,21 @@ class TestResolveObjType:
     """Tests for ``IORegistry._resolve_obj_type``."""
 
     def test_exact_match(self) -> None:
-        assert IORegistry._resolve_obj_type(dict, [dict, object]) is dict
+        assert (
+            LoaderRegistry._resolve_obj_type(".csv", pd.DataFrame)
+            is pd.DataFrame
+        )
 
     def test_subclass_fallback(self) -> None:
-        assert IORegistry._resolve_obj_type(dict, [object]) is object
+        assert LoaderRegistry._resolve_obj_type(".pkl", dict) is object
 
     def test_none_returns_last_registered(self) -> None:
         """When *obj_type* is ``None`` the last (default) entry is returned."""
-        assert (
-            IORegistry._resolve_obj_type(None, [pd.DataFrame, object]) is object
-        )
+        assert LoaderRegistry._resolve_obj_type(".json", None) is object
 
     def test_no_match_raises(self) -> None:
         with pytest.raises(TypeError, match="Cannot resolve"):
-            IORegistry._resolve_obj_type(int, [pd.DataFrame])
+            LoaderRegistry._resolve_obj_type(".csv", int)
 
 
 # ---------------------------------------------------------------------------
@@ -84,11 +85,11 @@ class TestLoaderRegistry:
             LoaderRegistry.get_loader(".csv", obj_type=int)
 
     def test_loader_obj_types_csv(self) -> None:
-        obj_types = LoaderRegistry._io_obj_types[".csv"]
+        obj_types = LoaderRegistry._obj_types[".csv"]
         assert pd.DataFrame in obj_types
 
     def test_loader_obj_types_json_has_object(self) -> None:
-        obj_types = LoaderRegistry._io_obj_types[".json"]
+        obj_types = LoaderRegistry._obj_types[".json"]
         assert object in obj_types
 
 

--- a/tests/data/test_io.py
+++ b/tests/data/test_io.py
@@ -5,13 +5,9 @@ import pandas as pd
 import pytest
 
 from pplkit.data.io import (
-    get_default_loader,
-    get_dumper,
-    get_dumper_obj_types,
-    get_loader,
-    get_loader_obj_types,
-    resolve_obj_type,
-    resolve_suffix,
+    DumperRegistry,
+    IORegistry,
+    LoaderRegistry,
 )
 
 
@@ -20,57 +16,114 @@ def data() -> dict[str, list[int]]:
     return {"a": [1, 2, 3], "b": [4, 5, 6]}
 
 
+# ---------------------------------------------------------------------------
+# Suffix alias resolution
+# ---------------------------------------------------------------------------
+
+
 class TestSuffixAlias:
-    def test_resolve_known_alias(self) -> None:
-        assert resolve_suffix(".pickle") == ".pkl"
-        assert resolve_suffix(".yml") == ".yaml"
+    """Tests for ``IORegistry._resolve_suffix`` and alias registration."""
 
-    def test_resolve_canonical(self) -> None:
-        assert resolve_suffix(".csv") == ".csv"
-        assert resolve_suffix(".json") == ".json"
+    def test_resolve_known_alias_pickle(self) -> None:
+        assert IORegistry._resolve_suffix(".pickle") == ".pkl"
 
-    def test_resolve_unknown(self) -> None:
-        assert resolve_suffix(".xyz") == ".xyz"
+    def test_resolve_known_alias_yml(self) -> None:
+        assert IORegistry._resolve_suffix(".yml") == ".yaml"
+
+    def test_resolve_canonical_suffix(self) -> None:
+        assert IORegistry._resolve_suffix(".csv") == ".csv"
+        assert IORegistry._resolve_suffix(".json") == ".json"
+
+    def test_resolve_unknown_suffix_returns_as_is(self) -> None:
+        assert IORegistry._resolve_suffix(".xyz") == ".xyz"
+
+
+# ---------------------------------------------------------------------------
+# Object-type resolution
+# ---------------------------------------------------------------------------
 
 
 class TestResolveObjType:
+    """Tests for ``IORegistry._resolve_obj_type``."""
+
     def test_exact_match(self) -> None:
-        assert resolve_obj_type(dict, [dict, object]) is dict
+        assert IORegistry._resolve_obj_type(dict, [dict, object]) is dict
 
     def test_subclass_fallback(self) -> None:
-        assert resolve_obj_type(dict, [object]) is object
+        assert IORegistry._resolve_obj_type(dict, [object]) is object
 
-    def test_no_match(self) -> None:
+    def test_none_returns_last_registered(self) -> None:
+        """When *obj_type* is ``None`` the last (default) entry is returned."""
+        assert (
+            IORegistry._resolve_obj_type(None, [pd.DataFrame, object]) is object
+        )
+
+    def test_no_match_raises(self) -> None:
         with pytest.raises(TypeError, match="Cannot resolve"):
-            resolve_obj_type(int, [pd.DataFrame])
+            IORegistry._resolve_obj_type(int, [pd.DataFrame])
 
 
-class TestGetLoader:
+# ---------------------------------------------------------------------------
+# LoaderRegistry
+# ---------------------------------------------------------------------------
+
+
+class TestLoaderRegistry:
+    """Tests for ``LoaderRegistry.get_loader``."""
+
     def test_get_default_loader(self) -> None:
-        loader = get_default_loader(".csv")
+        loader = LoaderRegistry.get_loader(".csv")
         assert callable(loader)
 
-    def test_get_loader_by_type(self) -> None:
-        loader = get_loader(".csv", pd.DataFrame)
+    def test_get_loader_by_obj_type(self) -> None:
+        loader = LoaderRegistry.get_loader(".csv", obj_type=pd.DataFrame)
         assert callable(loader)
 
-    def test_get_loader_missing_key(self) -> None:
-        with pytest.raises(KeyError):
-            get_loader(".csv", dict)
+    def test_get_loader_missing_obj_type_raises(self) -> None:
+        with pytest.raises(TypeError, match="Cannot resolve"):
+            LoaderRegistry.get_loader(".csv", obj_type=int)
 
-    def test_get_loader_obj_types(self) -> None:
-        obj_types = get_loader_obj_types(".csv")
+    def test_loader_obj_types_csv(self) -> None:
+        obj_types = LoaderRegistry._io_obj_types[".csv"]
         assert pd.DataFrame in obj_types
 
-    def test_get_loader_obj_types_with_object(self) -> None:
-        obj_types = get_loader_obj_types(".json")
+    def test_loader_obj_types_json_has_object(self) -> None:
+        obj_types = LoaderRegistry._io_obj_types[".json"]
         assert object in obj_types
+
+
+# ---------------------------------------------------------------------------
+# DumperRegistry
+# ---------------------------------------------------------------------------
+
+
+class TestDumperRegistry:
+    """Tests for ``DumperRegistry.get_dumper``."""
+
+    def test_get_dumper(self) -> None:
+        dumper = DumperRegistry.get_dumper(".csv", pd.DataFrame)
+        assert callable(dumper)
+
+    def test_get_dumper_via_subclass_resolution(self) -> None:
+        dumper = DumperRegistry.get_dumper(".pkl", dict)
+        assert callable(dumper)
+
+    def test_get_dumper_missing_obj_type_raises(self) -> None:
+        with pytest.raises(TypeError, match="Cannot resolve"):
+            DumperRegistry.get_dumper(".csv", int)
+
+
+# ---------------------------------------------------------------------------
+# Round-trip integration tests
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize(
     "suffix", [".csv", ".pkl", ".yaml", ".parquet", ".json", ".toml"]
 )
 class TestLoaderDumperRoundTrip:
+    """Dump then load for every registered format and verify data integrity."""
+
     def test_round_trip(
         self,
         data: dict[str, list[int]],
@@ -78,13 +131,12 @@ class TestLoaderDumperRoundTrip:
         tmp_path: pathlib.Path,
     ) -> None:
         path = tmp_path / f"data{suffix}"
-        obj = pd.DataFrame(data) if suffix in [".csv", ".parquet"] else data
+        obj = pd.DataFrame(data) if suffix in {".csv", ".parquet"} else data
 
-        obj_type = resolve_obj_type(type(obj), get_dumper_obj_types(suffix))
-        dumper = get_dumper(suffix, obj_type)
+        dumper = DumperRegistry.get_dumper(suffix, type(obj))
         dumper(obj, path)
 
-        loader = get_default_loader(suffix)
+        loader = LoaderRegistry.get_loader(suffix)
         loaded_data = loader(path)
 
         for key in ["a", "b"]:
@@ -92,16 +144,18 @@ class TestLoaderDumperRoundTrip:
 
 
 class TestSuffixAliasRoundTrip:
+    """Verify that suffix aliases work end-to-end through dump/load."""
+
     def test_pickle_alias(
         self, data: dict[str, list[int]], tmp_path: pathlib.Path
     ) -> None:
         path = tmp_path / "data.pickle"
-        resolved = resolve_suffix(path.suffix)
+        resolved = IORegistry._resolve_suffix(path.suffix)
 
-        dumper = get_dumper(resolved, object)
+        dumper = DumperRegistry.get_dumper(resolved, object)
         dumper(data, path)
 
-        loader = get_default_loader(resolved)
+        loader = LoaderRegistry.get_loader(resolved)
         loaded_data = loader(path)
 
         for key in ["a", "b"]:
@@ -111,20 +165,27 @@ class TestSuffixAliasRoundTrip:
         self, data: dict[str, list[int]], tmp_path: pathlib.Path
     ) -> None:
         path = tmp_path / "data.yml"
-        resolved = resolve_suffix(path.suffix)
+        resolved = IORegistry._resolve_suffix(path.suffix)
 
-        dumper = get_dumper(resolved, object)
+        dumper = DumperRegistry.get_dumper(resolved, object)
         dumper(data, path)
 
-        loader = get_default_loader(resolved)
+        loader = LoaderRegistry.get_loader(resolved)
         loaded_data = loader(path)
 
         for key in ["a", "b"]:
             assert np.allclose(data[key], loaded_data[key])
 
 
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
 class TestLoadMissingFile:
+    """Loading a nonexistent file should surface a ``FileNotFoundError``."""
+
     def test_missing_file(self, tmp_path: pathlib.Path) -> None:
-        loader = get_default_loader(".json")
+        loader = LoaderRegistry.get_loader(".json")
         with pytest.raises(FileNotFoundError):
             loader(tmp_path / "nonexistent.json")

--- a/tests/data/test_io.py
+++ b/tests/data/test_io.py
@@ -4,7 +4,15 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from pplkit.data.io import CSVIO, JSONIO, TOMLIO, YAMLIO, ParquetIO, PickleIO
+from pplkit.data.io import (
+    get_default_loader,
+    get_dumper,
+    get_dumper_obj_types,
+    get_loader,
+    get_loader_obj_types,
+    resolve_obj_type,
+    resolve_suffix,
+)
 
 
 @pytest.fixture
@@ -12,56 +20,111 @@ def data() -> dict[str, list[int]]:
     return {"a": [1, 2, 3], "b": [4, 5, 6]}
 
 
-def test_csvio(data: dict[str, list[int]], tmp_path: pathlib.Path) -> None:
-    df = pd.DataFrame(data)
-    CSVIO.dump(df, tmp_path / "file.csv")
-    loaded_data = CSVIO.load(tmp_path / "file.csv")
+class TestSuffixAlias:
+    def test_resolve_known_alias(self) -> None:
+        assert resolve_suffix(".pickle") == ".pkl"
+        assert resolve_suffix(".yml") == ".yaml"
 
-    for key in ["a", "b"]:
-        assert np.allclose(data[key], loaded_data[key])
+    def test_resolve_canonical(self) -> None:
+        assert resolve_suffix(".csv") == ".csv"
+        assert resolve_suffix(".json") == ".json"
 
-
-def test_jsonio(data: dict[str, list[int]], tmp_path: pathlib.Path) -> None:
-    JSONIO.dump(data, tmp_path / "file.json")
-    loaded_data = JSONIO.load(tmp_path / "file.json")
-
-    for key in ["a", "b"]:
-        assert np.allclose(data[key], loaded_data[key])
+    def test_resolve_unknown(self) -> None:
+        assert resolve_suffix(".xyz") == ".xyz"
 
 
-def test_yamlio(data: dict[str, list[int]], tmp_path: pathlib.Path) -> None:
-    YAMLIO.dump(data, tmp_path / "file.yaml")
-    loaded_data = YAMLIO.load(tmp_path / "file.yaml")
+class TestResolveObjType:
+    def test_exact_match(self) -> None:
+        assert resolve_obj_type(dict, [dict, object]) is dict
 
-    for key in ["a", "b"]:
-        assert np.allclose(data[key], loaded_data[key])
+    def test_subclass_fallback(self) -> None:
+        assert resolve_obj_type(dict, [object]) is object
 
-
-def test_parquetio(data: dict[str, list[int]], tmp_path: pathlib.Path) -> None:
-    df = pd.DataFrame(data)
-    ParquetIO.dump(df, tmp_path / "file.parquet")
-    loaded_data = ParquetIO.load(tmp_path / "file.parquet")
-
-    for key in ["a", "b"]:
-        assert np.allclose(data[key], loaded_data[key])
+    def test_no_match(self) -> None:
+        with pytest.raises(TypeError, match="Cannot resolve"):
+            resolve_obj_type(int, [pd.DataFrame])
 
 
-def test_pickleio(data: dict[str, list[int]], tmp_path: pathlib.Path) -> None:
-    PickleIO.dump(data, tmp_path / "file.pkl")
-    loaded_data = PickleIO.load(tmp_path / "file.pkl")
+class TestGetLoader:
+    def test_get_default_loader(self) -> None:
+        loader = get_default_loader(".csv")
+        assert callable(loader)
 
-    for key in ["a", "b"]:
-        assert np.allclose(data[key], loaded_data[key])
+    def test_get_loader_by_type(self) -> None:
+        loader = get_loader(".csv", pd.DataFrame)
+        assert callable(loader)
+
+    def test_get_loader_missing_key(self) -> None:
+        with pytest.raises(KeyError):
+            get_loader(".csv", dict)
+
+    def test_get_loader_obj_types(self) -> None:
+        obj_types = get_loader_obj_types(".csv")
+        assert pd.DataFrame in obj_types
+
+    def test_get_loader_obj_types_with_object(self) -> None:
+        obj_types = get_loader_obj_types(".json")
+        assert object in obj_types
 
 
-def test_tomlio(data: dict[str, list[int]], tmp_path: pathlib.Path) -> None:
-    TOMLIO.dump(data, tmp_path / "file.toml")
-    loaded_data = TOMLIO.load(tmp_path / "file.toml")
+@pytest.mark.parametrize(
+    "suffix", [".csv", ".pkl", ".yaml", ".parquet", ".json", ".toml"]
+)
+class TestLoaderDumperRoundTrip:
+    def test_round_trip(
+        self,
+        data: dict[str, list[int]],
+        suffix: str,
+        tmp_path: pathlib.Path,
+    ) -> None:
+        path = tmp_path / f"data{suffix}"
+        obj = pd.DataFrame(data) if suffix in [".csv", ".parquet"] else data
 
-    for key in ["a", "b"]:
-        assert np.allclose(data[key], loaded_data[key])
+        obj_type = resolve_obj_type(type(obj), get_dumper_obj_types(suffix))
+        dumper = get_dumper(suffix, obj_type)
+        dumper(obj, path)
+
+        loader = get_default_loader(suffix)
+        loaded_data = loader(path)
+
+        for key in ["a", "b"]:
+            assert np.allclose(data[key], loaded_data[key])
 
 
-def test_load_missing_file(tmp_path: pathlib.Path) -> None:
-    with pytest.raises(FileNotFoundError):
-        JSONIO.load(tmp_path / "nonexistent.json")
+class TestSuffixAliasRoundTrip:
+    def test_pickle_alias(
+        self, data: dict[str, list[int]], tmp_path: pathlib.Path
+    ) -> None:
+        path = tmp_path / "data.pickle"
+        resolved = resolve_suffix(path.suffix)
+
+        dumper = get_dumper(resolved, object)
+        dumper(data, path)
+
+        loader = get_default_loader(resolved)
+        loaded_data = loader(path)
+
+        for key in ["a", "b"]:
+            assert np.allclose(data[key], loaded_data[key])
+
+    def test_yml_alias(
+        self, data: dict[str, list[int]], tmp_path: pathlib.Path
+    ) -> None:
+        path = tmp_path / "data.yml"
+        resolved = resolve_suffix(path.suffix)
+
+        dumper = get_dumper(resolved, object)
+        dumper(data, path)
+
+        loader = get_default_loader(resolved)
+        loaded_data = loader(path)
+
+        for key in ["a", "b"]:
+            assert np.allclose(data[key], loaded_data[key])
+
+
+class TestLoadMissingFile:
+    def test_missing_file(self, tmp_path: pathlib.Path) -> None:
+        loader = get_default_loader(".json")
+        with pytest.raises(FileNotFoundError):
+            loader(tmp_path / "nonexistent.json")


### PR DESCRIPTION
## Summary

Refactor the I/O layer from class-based `IO` subclasses (`CSVIO`, `PickleIO`, etc.) to a decorator-driven registry pattern (`IORegistry`, `LoaderRegistry`, `DumperRegistry`). Refactor `DataInterface` to use explicit `load`/`dump` methods instead of dynamic attribute access. Add comprehensive NumPy-style docstrings throughout.

## What Changed

**New files**
- None

**Modified files**
- `src/pplkit/data/io.py`
  - Replaced `IO` ABC and per-format subclasses (`CSVIO`, `PickleIO`, `YAMLIO`, etc.) with `IORegistry` base class and `LoaderRegistry`/`DumperRegistry` subclasses
  - Added `Loader`/`Dumper` protocols and `Suffix`/`SuffixAlias` type aliases
  - Loader/dumper functions are now registered via `@Registry.register(suffix, obj_type)` decorators
  - Suffix alias support (`.pickle` → `.pkl`, `.yml` → `.yaml`)
  - Added docstrings to all public/private classes, methods, protocols, and type aliases
- `src/pplkit/data/interface.py`
  - `DataInterface` now uses `LoaderRegistry`/`DumperRegistry` instead of `SUFFIX_TO_IO` mapping
  - Reordered methods: `__init__` → public (`load`, `dump`) → dunders → `__repr__`
  - Added module-level and method-level NumPy-style docstrings
- `tests/data/test_io.py`
  - Rewrote all tests to use the new registry API (`LoaderRegistry`, `DumperRegistry`, `IORegistry`)
  - Added `TestDumperRegistry` class and `TestResolveObjType.test_none_returns_last_registered`
  - Updated internal attribute references (`_io_obj_types` → `_obj_types`)

**Deleted files**
- None